### PR TITLE
Dev tidb adaptor

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -316,3 +316,16 @@ func Unwrap(err error) error {
 	}
 	return nil
 }
+
+// Find an error in the chain that matches a test function
+func Find(origErr error, test func(error) bool) error {
+	var foundErr error
+	WalkDeep(origErr, func(err error) bool {
+		if test(err) {
+			foundErr = err
+			return true
+		}
+		return false
+	})
+	return foundErr
+}

--- a/errors.go
+++ b/errors.go
@@ -303,16 +303,21 @@ func (w *withMessage) Format(s fmt.State, verb rune) {
 // be returned. If the error is nil, nil will be returned without further
 // investigation.
 func Cause(err error) error {
+	cause := Unwrap(err)
+	if cause == nil {
+		return err
+	}
+	return Cause(cause)
+}
+
+// Unwrap uses causer to return the next error in the chain or nil.
+// This goes one-level deeper, whereas Cause goes as far as possible
+func Unwrap(err error) error {
 	type causer interface {
 		Cause() error
 	}
-
-	for err != nil {
-		cause, ok := err.(causer)
-		if !ok {
-			break
-		}
-		err = cause.Cause()
+	if unErr, ok := err.(causer); ok {
+		return unErr.Cause()
 	}
-	return err
+	return nil
 }

--- a/errors.go
+++ b/errors.go
@@ -194,10 +194,12 @@ func (w *withStack) hasStack() bool {
 	return true
 }
 
-// Annotate returns an error annotating err with a stack trace
+// Wrap returns an error annotating err with a stack trace
 // at the point Annotate is called, and the supplied message.
 // If err is nil, Annotate returns nil.
-func Annotate(err error, message string) error {
+//
+// Deprecated: use Annotate instead
+func Wrap(err error, message string) error {
 	if err == nil {
 		return nil
 	}
@@ -207,19 +209,18 @@ func Annotate(err error, message string) error {
 		msg:           message,
 		causeHasStack: hasStack,
 	}
-	if hasStack {
-		return err
-	}
 	return &withStack{
 		err,
 		callers(),
 	}
 }
 
-// Annotatef returns an error annotating err with a stack trace
+// Wrapf returns an error annotating err with a stack trace
 // at the point Annotatef is call, and the format specifier.
 // If err is nil, Annotatef returns nil.
-func Annotatef(err error, format string, args ...interface{}) error {
+//
+// Deprecated: use Annotatef instead
+func Wrapf(err error, format string, args ...interface{}) error {
 	if err == nil {
 		return nil
 	}
@@ -228,9 +229,6 @@ func Annotatef(err error, format string, args ...interface{}) error {
 		cause:         err,
 		msg:           fmt.Sprintf(format, args...),
 		causeHasStack: hasStack,
-	}
-	if hasStack {
-		return err
 	}
 	return &withStack{
 		err,

--- a/errors.go
+++ b/errors.go
@@ -172,21 +172,16 @@ func AddStack(err error) error {
 // This function is used by AddStack to avoid creating redundant stack traces.
 //
 // You can also use the StackTracer interface on the returned error to get the stack trace.
-func GetStackTracer(err error) StackTracer {
-	type causer interface {
-		Cause() error
-	}
-	for err != nil {
-		if stacked, ok := err.(StackTracer); ok {
-			return stacked
+func GetStackTracer(origErr error) StackTracer {
+	var stacked StackTracer
+	WalkDeep(origErr, func(err error) bool {
+		if stackTracer, ok := err.(StackTracer); ok {
+			stacked = stackTracer
+			return true
 		}
-		cause, ok := err.(causer)
-		if !ok {
-			return nil
-		}
-		err = cause.Cause()
-	}
-	return nil
+		return false
+	})
+	return stacked
 }
 
 type withStack struct {

--- a/errors_test.go
+++ b/errors_test.go
@@ -96,6 +96,12 @@ func TestCause(t *testing.T) {
 	}, {
 		WithStack(io.EOF),
 		io.EOF,
+	}, {
+		AddStack(nil),
+		nil,
+	}, {
+		AddStack(io.EOF),
+		io.EOF,
 	}}
 
 	for i, tt := range tests {
@@ -154,6 +160,10 @@ func TestWithStackNil(t *testing.T) {
 	if got != nil {
 		t.Errorf("WithStack(nil): got %#v, expected nil", got)
 	}
+	got = AddStack(nil)
+	if got != nil {
+		t.Errorf("AddStack(nil): got %#v, expected nil", got)
+	}
 }
 
 func TestWithStack(t *testing.T) {
@@ -170,6 +180,50 @@ func TestWithStack(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("WithStack(%v): got: %v, want %v", tt.err, got, tt.want)
 		}
+	}
+}
+
+func TestAddStack(t *testing.T) {
+	tests := []struct {
+		err  error
+		want string
+	}{
+		{io.EOF, "EOF"},
+		{AddStack(io.EOF), "EOF"},
+	}
+
+	for _, tt := range tests {
+		got := AddStack(tt.err).Error()
+		if got != tt.want {
+			t.Errorf("AddStack(%v): got: %v, want %v", tt.err, got, tt.want)
+		}
+	}
+}
+
+func TestGetStackTracer(t *testing.T) {
+	orig := io.EOF
+	if GetStackTracer(orig) != nil {
+		t.Errorf("GetStackTracer: got: %v, want %v", GetStackTracer(orig), nil)
+	}
+	stacked := AddStack(orig)
+	if GetStackTracer(stacked).(error) != stacked {
+		t.Errorf("GetStackTracer(stacked): got: %v, want %v", GetStackTracer(stacked), stacked)
+	}
+	final := AddStack(stacked)
+	if GetStackTracer(final).(error) != stacked {
+		t.Errorf("GetStackTracer(final): got: %v, want %v", GetStackTracer(final), stacked)
+	}
+}
+
+func TestAddStackDedup(t *testing.T) {
+	stacked := WithStack(io.EOF)
+	err := AddStack(stacked)
+	if err != stacked {
+		t.Errorf("AddStack: got: %+v, want %+v", err, stacked)
+	}
+	err = WithStack(stacked)
+	if err == stacked {
+		t.Errorf("WithStack: got: %v, don't want %v", err, stacked)
 	}
 }
 
@@ -215,6 +269,8 @@ func TestErrorEquality(t *testing.T) {
 		WithMessage(io.EOF, "whoops"),
 		WithStack(io.EOF),
 		WithStack(nil),
+		AddStack(io.EOF),
+		AddStack(nil),
 	}
 
 	for i := range vals {

--- a/format_test.go
+++ b/format_test.go
@@ -26,8 +26,8 @@ func TestFormatNew(t *testing.T) {
 		New("error"),
 		"%+v",
 		"error\n" +
-			"github.com/pingcap/errors.TestFormatNew\n" +
-			"\t.+/github.com/pingcap/errors/format_test.go:26",
+			"github.com/pkg/errors.TestFormatNew\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:26",
 	}, {
 		New("error"),
 		"%q",
@@ -56,8 +56,8 @@ func TestFormatErrorf(t *testing.T) {
 		Errorf("%s", "error"),
 		"%+v",
 		"error\n" +
-			"github.com/pingcap/errors.TestFormatErrorf\n" +
-			"\t.+/github.com/pingcap/errors/format_test.go:56",
+			"github.com/pkg/errors.TestFormatErrorf\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:56",
 	}}
 
 	for i, tt := range tests {
@@ -82,8 +82,8 @@ func TestFormatWrap(t *testing.T) {
 		Annotate(New("error"), "error2"),
 		"%+v",
 		"error\n" +
-			"github.com/pingcap/errors.TestFormatWrap\n" +
-			"\t.+/github.com/pingcap/errors/format_test.go:82",
+			"github.com/pkg/errors.TestFormatWrap\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:82",
 	}, {
 		Annotate(io.EOF, "error"),
 		"%s",
@@ -97,15 +97,15 @@ func TestFormatWrap(t *testing.T) {
 		"%+v",
 		"EOF\n" +
 			"error\n" +
-			"github.com/pingcap/errors.TestFormatWrap\n" +
-			"\t.+/github.com/pingcap/errors/format_test.go:96",
+			"github.com/pkg/errors.TestFormatWrap\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:96",
 	}, {
 		Annotate(Annotate(io.EOF, "error1"), "error2"),
 		"%+v",
 		"EOF\n" +
 			"error1\n" +
-			"github.com/pingcap/errors.TestFormatWrap\n" +
-			"\t.+/github.com/pingcap/errors/format_test.go:103\n",
+			"github.com/pkg/errors.TestFormatWrap\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:103\n",
 	}, {
 		Annotate(New("error with space"), "context"),
 		"%q",
@@ -135,8 +135,8 @@ func TestFormatWrapf(t *testing.T) {
 		"%+v",
 		"EOF\n" +
 			"error2\n" +
-			"github.com/pingcap/errors.TestFormatWrapf\n" +
-			"\t.+/github.com/pingcap/errors/format_test.go:134",
+			"github.com/pkg/errors.TestFormatWrapf\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:134",
 	}, {
 		Annotatef(New("error"), "error%d", 2),
 		"%s",
@@ -149,8 +149,8 @@ func TestFormatWrapf(t *testing.T) {
 		Annotatef(New("error"), "error%d", 2),
 		"%+v",
 		"error\n" +
-			"github.com/pingcap/errors.TestFormatWrapf\n" +
-			"\t.+/github.com/pingcap/errors/format_test.go:149",
+			"github.com/pkg/errors.TestFormatWrapf\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:149",
 	}}
 
 	for i, tt := range tests {
@@ -175,8 +175,8 @@ func TestFormatWithStack(t *testing.T) {
 		WithStack(io.EOF),
 		"%+v",
 		[]string{"EOF",
-			"github.com/pingcap/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:175"},
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:175"},
 	}, {
 		WithStack(New("error")),
 		"%s",
@@ -189,37 +189,37 @@ func TestFormatWithStack(t *testing.T) {
 		WithStack(New("error")),
 		"%+v",
 		[]string{"error",
-			"github.com/pingcap/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:189",
-			"github.com/pingcap/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:189"},
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:189",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:189"},
 	}, {
 		WithStack(WithStack(io.EOF)),
 		"%+v",
 		[]string{"EOF",
-			"github.com/pingcap/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:197",
-			"github.com/pingcap/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:197"},
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:197",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:197"},
 	}, {
 		WithStack(WithStack(Annotatef(io.EOF, "message"))),
 		"%+v",
 		[]string{"EOF",
 			"message",
-			"github.com/pingcap/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:205",
-			"github.com/pingcap/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:205",
-			"github.com/pingcap/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:205"},
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:205",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:205",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:205"},
 	}, {
 		WithStack(Errorf("error%d", 1)),
 		"%+v",
 		[]string{"error1",
-			"github.com/pingcap/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:216",
-			"github.com/pingcap/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:216"},
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:216",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:216"},
 	}}
 
 	for i, tt := range tests {
@@ -245,8 +245,8 @@ func TestFormatWithMessage(t *testing.T) {
 		"%+v",
 		[]string{
 			"error",
-			"github.com/pingcap/errors.TestFormatWithMessage\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:244",
+			"github.com/pkg/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:244",
 			"error2"},
 	}, {
 		WithMessage(io.EOF, "addition1"),
@@ -272,30 +272,30 @@ func TestFormatWithMessage(t *testing.T) {
 		Annotate(WithMessage(io.EOF, "error1"), "error2"),
 		"%+v",
 		[]string{"EOF", "error1", "error2",
-			"github.com/pingcap/errors.TestFormatWithMessage\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:272"},
+			"github.com/pkg/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:272"},
 	}, {
 		WithMessage(Errorf("error%d", 1), "error2"),
 		"%+v",
 		[]string{"error1",
-			"github.com/pingcap/errors.TestFormatWithMessage\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:278",
+			"github.com/pkg/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:278",
 			"error2"},
 	}, {
 		WithMessage(WithStack(io.EOF), "error"),
 		"%+v",
 		[]string{
 			"EOF",
-			"github.com/pingcap/errors.TestFormatWithMessage\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:285",
+			"github.com/pkg/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:285",
 			"error"},
 	}, {
 		WithMessage(Annotate(WithStack(io.EOF), "inside-error"), "outside-error"),
 		"%+v",
 		[]string{
 			"EOF",
-			"github.com/pingcap/errors.TestFormatWithMessage\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:293",
+			"github.com/pkg/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:293",
 			"inside-error",
 			"outside-error"},
 	}}
@@ -312,12 +312,12 @@ func TestFormatWithMessage(t *testing.T) {
 	}{
 		{New("new-error"), []string{
 			"new-error",
-			"github.com/pingcap/errors.TestFormatGeneric\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:313"},
+			"github.com/pkg/errors.TestFormatGeneric\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:313"},
 		}, {Errorf("errorf-error"), []string{
 			"errorf-error",
-			"github.com/pingcap/errors.TestFormatGeneric\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:317"},
+			"github.com/pkg/errors.TestFormatGeneric\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:317"},
 		}, {errors.New("errors-new-error"), []string{
 			"errors-new-error"},
 		},
@@ -330,22 +330,22 @@ func TestFormatWithMessage(t *testing.T) {
 		}, {
 			func(err error) error { return WithStack(err) },
 			[]string{
-				"github.com/pingcap/errors.(func·002|TestFormatGeneric.func2)\n\t" +
-					".+/github.com/pingcap/errors/format_test.go:331",
+				"github.com/pkg/errors.(func·002|TestFormatGeneric.func2)\n\t" +
+					".+/github.com/pkg/errors/format_test.go:331",
 			},
 		}, {
 			func(err error) error { return Annotate(err, "wrap-error") },
 			[]string{
 				"wrap-error",
-				"github.com/pingcap/errors.(func·003|TestFormatGeneric.func3)\n\t" +
-					".+/github.com/pingcap/errors/format_test.go:337",
+				"github.com/pkg/errors.(func·003|TestFormatGeneric.func3)\n\t" +
+					".+/github.com/pkg/errors/format_test.go:337",
 			},
 		}, {
 			func(err error) error { return Annotatef(err, "wrapf-error%d", 1) },
 			[]string{
 				"wrapf-error1",
-				"github.com/pingcap/errors.(func·004|TestFormatGeneric.func4)\n\t" +
-					".+/github.com/pingcap/errors/format_test.go:346",
+				"github.com/pkg/errors.(func·004|TestFormatGeneric.func4)\n\t" +
+					".+/github.com/pkg/errors/format_test.go:346",
 			},
 		},
 	}

--- a/format_test.go
+++ b/format_test.go
@@ -359,6 +359,7 @@ func TestFormatWithMessage(t *testing.T) {
 }*/
 
 func testFormatRegexp(t *testing.T, n int, arg interface{}, format, want string) {
+	t.Helper()
 	got := fmt.Sprintf(format, arg)
 	gotLines := strings.SplitN(got, "\n", -1)
 	wantLines := strings.SplitN(want, "\n", -1)

--- a/group.go
+++ b/group.go
@@ -1,0 +1,33 @@
+package errors
+
+// ErrorGroup is an interface for multiple errors that are not a chain.
+// This happens for example when executing multiple operations in parallel.
+type ErrorGroup interface {
+	Errors() []error
+}
+
+// WalkDeep does a depth-first traversal of all errors.
+// Any ErrorGroup is traversed (after going deep).
+// The visitor function can return false to end the traversal early
+// In that case, WalkDeep will return false, otherwise true
+func WalkDeep(err error, visitor func(err error) bool) bool {
+	// Go deep
+	unErr := err
+	for unErr != nil {
+		if more := visitor(unErr); more == true {
+			return true
+		}
+		unErr = Unwrap(unErr)
+	}
+
+	// Go wide
+	if hasGroup, ok := err.(ErrorGroup); ok {
+		for _, err := range hasGroup.Errors() {
+			if more := WalkDeep(err, visitor); more == true {
+				return true
+			}
+		}
+	}
+
+	return true
+}

--- a/juju_adaptor.go
+++ b/juju_adaptor.go
@@ -16,7 +16,7 @@ func Annotate(err error, message string) error {
 	if err == nil {
 		return nil
 	}
-	hasStack := errHasStack(err)
+	hasStack := HasStack(err)
 	err = &withMessage{
 		cause:         err,
 		msg:           message,
@@ -35,7 +35,7 @@ func Annotatef(err error, format string, args ...interface{}) error {
 	if err == nil {
 		return nil
 	}
-	hasStack := errHasStack(err)
+	hasStack := HasStack(err)
 	err = &withMessage{
 		cause:         err,
 		msg:           fmt.Sprintf(format, args...),

--- a/juju_adaptor.go
+++ b/juju_adaptor.go
@@ -2,8 +2,6 @@ package errors
 
 import (
 	"fmt"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // ==================== juju adaptor start ========================
@@ -11,10 +9,20 @@ import (
 // Trace annotates err with a stack trace at the point WithStack was called.
 // If err is nil or already contain stack trace return directly.
 func Trace(err error) error {
+	return AddStack(err)
+}
+
+func Annotate(err error, message string) error {
 	if err == nil {
 		return nil
 	}
-	if errHasStack(err) {
+	hasStack := errHasStack(err)
+	err = &withMessage{
+		cause:         err,
+		msg:           message,
+		causeHasStack: hasStack,
+	}
+	if hasStack {
 		return err
 	}
 	return &withStack{
@@ -23,19 +31,31 @@ func Trace(err error) error {
 	}
 }
 
-// error passed as the parameter is not an annotated error, the result is		 // error passed as the parameter is not an annotated error, the result is
-// simply the result of the Error() method on that error.		 // simply the result of the Error() method on that error.
+func Annotatef(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	hasStack := errHasStack(err)
+	err = &withMessage{
+		cause:         err,
+		msg:           fmt.Sprintf(format, args...),
+		causeHasStack: hasStack,
+	}
+	if hasStack {
+		return err
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// ErrorStack will format a stack trace if it is available, otherwise it will be Error()
 func ErrorStack(err error) string {
 	if err == nil {
 		return ""
 	}
 	return fmt.Sprintf("%+v", err)
-}
-
-// Wrap changes the Cause of the error, old error stack also be output.
-func Wrap(oldErr, newErr error) error {
-	log.Errorf("%+v", oldErr)
-	return Trace(newErr)
 }
 
 // NotFoundf represents an error with not found message.

--- a/stack.go
+++ b/stack.go
@@ -8,6 +8,12 @@ import (
 	"strings"
 )
 
+// StackTracer retrieves the StackTrace
+// Generally you would want to use the GetStackTracer function to do that.
+type StackTracer interface {
+	StackTrace() StackTrace
+}
+
 // Frame represents a program counter inside a stack frame.
 type Frame uintptr
 

--- a/stack_test.go
+++ b/stack_test.go
@@ -65,8 +65,8 @@ func TestFrameFormat(t *testing.T) {
 	}, {
 		Frame(initpc),
 		"%+s",
-		"github.com/pingcap/errors.init\n" +
-			"\t.+/github.com/pingcap/errors/stack_test.go",
+		"github.com/pkg/errors.init\n" +
+			"\t.+/github.com/pkg/errors/stack_test.go",
 	}, {
 		Frame(0),
 		"%s",
@@ -112,8 +112,8 @@ func TestFrameFormat(t *testing.T) {
 	}, {
 		Frame(initpc),
 		"%+v",
-		"github.com/pingcap/errors.init\n" +
-			"\t.+/github.com/pingcap/errors/stack_test.go:9",
+		"github.com/pkg/errors.init\n" +
+			"\t.+/github.com/pkg/errors/stack_test.go:9",
 	}, {
 		Frame(0),
 		"%v",
@@ -131,7 +131,7 @@ func TestFuncname(t *testing.T) {
 	}{
 		{"", ""},
 		{"runtime.main", "main"},
-		{"github.com/pingcap/errors.funcname", "funcname"},
+		{"github.com/pkg/errors.funcname", "funcname"},
 		{"funcname", "funcname"},
 		{"io.copyBuffer", "copyBuffer"},
 		{"main.(*R).Write", "(*R).Write"},
@@ -152,25 +152,25 @@ func TestStackTrace(t *testing.T) {
 		want []string
 	}{{
 		New("ooh"), []string{
-			"github.com/pingcap/errors.TestStackTrace\n" +
-				"\t.+/github.com/pingcap/errors/stack_test.go:154",
+			"github.com/pkg/errors.TestStackTrace\n" +
+				"\t.+/github.com/pkg/errors/stack_test.go:154",
 		},
 	}, {
 		Annotate(New("ooh"), "ahh"), []string{
-			"github.com/pingcap/errors.TestStackTrace\n" +
-				"\t.+/github.com/pingcap/errors/stack_test.go:159", // this is the stack of Wrap, not New
+			"github.com/pkg/errors.TestStackTrace\n" +
+				"\t.+/github.com/pkg/errors/stack_test.go:159", // this is the stack of Wrap, not New
 		},
 	}, {
 		Cause(Annotate(New("ooh"), "ahh")), []string{
-			"github.com/pingcap/errors.TestStackTrace\n" +
-				"\t.+/github.com/pingcap/errors/stack_test.go:164", // this is the stack of New
+			"github.com/pkg/errors.TestStackTrace\n" +
+				"\t.+/github.com/pkg/errors/stack_test.go:164", // this is the stack of New
 		},
 	}, {
 		func() error { return New("ooh") }(), []string{
-			`github.com/pingcap/errors.(func·009|TestStackTrace.func1)` +
-				"\n\t.+/github.com/pingcap/errors/stack_test.go:169", // this is the stack of New
-			"github.com/pingcap/errors.TestStackTrace\n" +
-				"\t.+/github.com/pingcap/errors/stack_test.go:169", // this is the stack of New's caller
+			`github.com/pkg/errors.(func·009|TestStackTrace.func1)` +
+				"\n\t.+/github.com/pkg/errors/stack_test.go:169", // this is the stack of New
+			"github.com/pkg/errors.TestStackTrace\n" +
+				"\t.+/github.com/pkg/errors/stack_test.go:169", // this is the stack of New's caller
 		},
 	}, {
 		Cause(func() error {
@@ -178,12 +178,12 @@ func TestStackTrace(t *testing.T) {
 				return Errorf("hello %s", fmt.Sprintf("world"))
 			}()
 		}()), []string{
-			`github.com/pingcap/errors.(func·010|TestStackTrace.func2.1)` +
-				"\n\t.+/github.com/pingcap/errors/stack_test.go:178", // this is the stack of Errorf
-			`github.com/pingcap/errors.(func·011|TestStackTrace.func2)` +
-				"\n\t.+/github.com/pingcap/errors/stack_test.go:179", // this is the stack of Errorf's caller
-			"github.com/pingcap/errors.TestStackTrace\n" +
-				"\t.+/github.com/pingcap/errors/stack_test.go:180", // this is the stack of Errorf's caller's caller
+			`github.com/pkg/errors.(func·010|TestStackTrace.func2.1)` +
+				"\n\t.+/github.com/pkg/errors/stack_test.go:178", // this is the stack of Errorf
+			`github.com/pkg/errors.(func·011|TestStackTrace.func2)` +
+				"\n\t.+/github.com/pkg/errors/stack_test.go:179", // this is the stack of Errorf's caller
+			"github.com/pkg/errors.TestStackTrace\n" +
+				"\t.+/github.com/pkg/errors/stack_test.go:180", // this is the stack of Errorf's caller's caller
 		},
 	}}
 	for i, tt := range tests {
@@ -268,10 +268,10 @@ func TestStackTraceFormat(t *testing.T) {
 		stackTrace()[:2],
 		"%+v",
 		"\n" +
-			"github.com/pingcap/errors.stackTrace\n" +
-			"\t.+/github.com/pingcap/errors/stack_test.go:217\n" +
-			"github.com/pingcap/errors.TestStackTraceFormat\n" +
-			"\t.+/github.com/pingcap/errors/stack_test.go:268",
+			"github.com/pkg/errors.stackTrace\n" +
+			"\t.+/github.com/pkg/errors/stack_test.go:217\n" +
+			"github.com/pkg/errors.TestStackTraceFormat\n" +
+			"\t.+/github.com/pkg/errors/stack_test.go:268",
 	}, {
 		stackTrace()[:2],
 		"%#v",

--- a/stack_test.go
+++ b/stack_test.go
@@ -187,13 +187,6 @@ func TestStackTrace(t *testing.T) {
 		},
 	}}
 	for i, tt := range tests {
-		_, ok := tt.err.(interface {
-			hasStack() bool
-		})
-		if !ok {
-			t.Errorf("expected %#v to implement StackTrace() StackTrace %v", tt.err, tt.want)
-			continue
-		}
 		ste, ok := tt.err.(interface {
 			StackTrace() StackTrace
 		})
@@ -263,19 +256,19 @@ func TestStackTraceFormat(t *testing.T) {
 	}, {
 		stackTrace()[:2],
 		"%v",
-		`[stack_test.go:217 stack_test.go:276]`,
+		`[stack_test.go:207 stack_test.go:254]`,
 	}, {
 		stackTrace()[:2],
 		"%+v",
 		"\n" +
 			"github.com/pkg/errors.stackTrace\n" +
-			"\t.+/github.com/pkg/errors/stack_test.go:217\n" +
+			"\t.+/github.com/pkg/errors/stack_test.go:210\n" +
 			"github.com/pkg/errors.TestStackTraceFormat\n" +
-			"\t.+/github.com/pkg/errors/stack_test.go:268",
+			"\t.+/github.com/pkg/errors/stack_test.go:261",
 	}, {
 		stackTrace()[:2],
 		"%#v",
-		`\[\]errors.Frame{stack_test.go:217, stack_test.go:276}`,
+		`\[\]errors.Frame{stack_test.go:210, stack_test.go:269}`,
 	}}
 
 	for i, tt := range tests {


### PR DESCRIPTION
This maintains the existing pkg/errors interface. I think its confusing for us to make changes to the behavior. If we can just use new functions (Annotate/Annotatef and AddStack) I believe that is a better approach.
Similarly, I think its better not to find and replace the github name in the tests, etc. Its very useful to have an easy comparison to the original package.

This incorporates code I wrote for traversing the error chain. `HasStack` is more robust by checking for `StackTracer` and checking the `ErrorGroup` interface.

This PR exposes StackTracer, GetStackTracer, HasStack, and WalkDeep.

I also added a `Find` function for searching the error chain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lysu/errors/2)
<!-- Reviewable:end -->
